### PR TITLE
Fixed typo in list index

### DIFF
--- a/squash/dashboard/viz/metrics.py
+++ b/squash/dashboard/viz/metrics.py
@@ -210,7 +210,7 @@ class Metrics(object):
 
         for i, current in enumerate(self.data['ci_id']):
             if i < last:
-                next = self.data['ci_id'][i+i]
+                next = self.data['ci_id'][i+1]
                 if (next - current) > 1:
                     start.append(time.mktime(
                         self.data['dates'][i].timetuple())*1000)


### PR DESCRIPTION
This bug was found only when reading data from the production database, still pending a good explanation on how it works with test data.