### PR TITLE
Metrics app should not fail if db is empty

### DIFF
--- a/squash/dashboard/viz/metrics.py
+++ b/squash/dashboard/viz/metrics.py
@@ -55,8 +55,7 @@ class Metrics(object):
 
         metric_select.on_change("value", self.on_metric_change)
 
-        if self.selected_dataset and self.selected_metric:
-            self.data = \
+        self.data = \
                 get_meas_by_dataset_and_metric(self.selected_dataset,
                                                self.selected_metric)
         self.update_data_source()


### PR DESCRIPTION
The metrics app should not fail if there is not data in the db, this commit fixes that. Note that there is a new command in the README instructions to load test data for developers.
