### PR TITLE
Added parameters to the metrics app URL

### DIFF
--- a/squash/dashboard/serializers.py
+++ b/squash/dashboard/serializers.py
@@ -35,6 +35,8 @@ class MeasurementSerializer(serializers.ModelSerializer):
 
 class MetricsAppSerializer(serializers.ModelSerializer):
 
+    units = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
     ci_id = serializers.SerializerMethodField()
     ci_url = serializers.SerializerMethodField()
     date = serializers.SerializerMethodField()
@@ -43,7 +45,13 @@ class MetricsAppSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Measurement
-        fields = ('value', 'ci_id', 'ci_url', 'date', "changed_packages")
+        fields = ('value', 'units', 'description', 'ci_id', 'ci_url', 'date', 'changed_packages')
+
+    def get_units(self, obj):
+        return obj.metric.units
+
+    def get_description(self, obj):
+        return obj.metric.description
 
     def get_ci_id(self, obj):
         return obj.job.ci_id

--- a/squash/dashboard/viz/metrics.py
+++ b/squash/dashboard/viz/metrics.py
@@ -6,7 +6,8 @@ from bokeh.models.widgets import Select, Div, DataTable, TableColumn,\
                                  DateFormatter, HTMLTemplateFormatter
 from bokeh.layouts import row, widgetbox, column
 from defaults import init_time_series_plot
-from service import get_datasets, get_metrics, get_meas_by_dataset_and_metric
+from service import get_datasets, get_metrics, get_meas_by_dataset_and_metric,\
+                    get_args
 
 
 class Metrics(object):
@@ -35,8 +36,21 @@ class Metrics(object):
         select the dataset, the metric, a div for the title, a plot and a table
         """
 
+        # Load metrics and datasets
+        self.metrics = get_metrics()
         self.datasets = get_datasets()
-        self.selected_dataset = self.datasets['default']
+
+        # Get args from the app URL or use defaults
+        args = get_args(doc=curdoc,
+                        defaults=[('metric', self.metrics['default']),
+                                  ('job__ci_dataset', self.datasets['default']),
+                                  ('window', 'months')])
+
+        self.selected_dataset = args['job__ci_dataset']
+
+        self.selected_metric = args['metric']
+
+        self.selected_window = args['window']
 
         # dataset select widget
         dataset_select = Select(title="Data Set:",
@@ -44,9 +58,6 @@ class Metrics(object):
                                 options=self.datasets['datasets'], width=100)
 
         dataset_select.on_change("value", self.on_dataset_change)
-
-        self.metrics = get_metrics()
-        self.selected_metric = self.metrics['default']
 
         # thresholds are used to make plot annotations
         self.configure_thresholds()
@@ -59,14 +70,16 @@ class Metrics(object):
 
         self.data = \
             get_meas_by_dataset_and_metric(self.selected_dataset,
-                                           self.selected_metric)
+                                           self.selected_metric,
+                                           self.selected_window)
         if len(self.data['values']) > 0:
 
             self.update_data_source()
             self.make_plot()
             self.make_table()
 
-            self.layout = row(widgetbox(dataset_select, metric_select,
+            self.layout = row(widgetbox(dataset_select,
+                                        metric_select,
                                         width=150),
                               column(widgetbox(self.title, width=1000),
                                      self.plot,

--- a/squash/dashboard/viz/metrics.py
+++ b/squash/dashboard/viz/metrics.py
@@ -109,7 +109,8 @@ class Metrics(object):
         """
 
         self.data = \
-            get_meas_by_dataset_and_metric(new, self.selected_metric)
+            get_meas_by_dataset_and_metric(new, self.selected_metric,
+                                           self.selected_window)
 
         self.selected_dataset = new
 
@@ -147,7 +148,8 @@ class Metrics(object):
         self.selected_metric = new
 
         self.data = \
-            get_meas_by_dataset_and_metric(self.selected_dataset, new)
+            get_meas_by_dataset_and_metric(self.selected_dataset, new,
+                                           self.selected_window)
 
         self.update_data_source()
 


### PR DESCRIPTION
- when calling the metrics app the job__ci_dataset, metric and window
parameters can now be specified at the app URL

- the new parameter window set the time window for the time series
plot, the allowed values are "weeks", "months" (default) and "years"

When deployed to production, a typical URL would be:

https://bokeh.lsst.codes/metrics?job__ci_dataset=cfht&metric=AM1&window=weeks