### PR TITLE
Create a Dockerfile for squash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Docker image for squash development
+FROM python:3.5
+
+LABEL maintainer "afausti@lsst.org"
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+# squash dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# other dependencies required to run this image
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client supervisor \
+    && mkdir -p /var/log/supervisor
+
+WORKDIR /usr/src/app/squash
+
+# Initialize squash development database
+ENV user root
+
+RUN /etc/init.d/mysql start \
+    && mysql -u ${user} -e "CREATE DATABASE qadb" \
+    && python -Wi manage.py makemigrations \
+    && python -Wi manage.py migrate \
+    && python -Wi manage.py createsuperuser --noinput --username ${user} --email root@example.com \
+    && python -Wi manage.py loaddata test_data
+
+# on the localhost django will run on port 8000 and bokeh on 5006
+EXPOSE 8000 5006
+
+# Start mysql, django and bokeh servers
+CMD ["/usr/bin/supervisord", "-c", "supervisord.conf"]
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t lsstsqre/squash .

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
-build:
+all:
 	docker build -t lsstsqre/squash .
+	docker run -it -p 5006:5006 -p 8000:8000 lsstsqre/squash

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the instructions below.
 
 ```
   git clone  https://github.com/lsst-sqre/qa-dashboard.git
-  make
+  docker build -t lsstsqre/squash .
   docker run -it -p 5006:5006 -p 8000:8000 lsstsqre/squash
 ```
 Then access the application at http://localhost:8000 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # qa-dashboard
 
+For SQuaSH development you can build a docker image 
+or install the dependencies on a virtual environment following 
+the instructions below.
+
+## Building a docker image
+
+```
+  git clone  https://github.com/lsst-sqre/qa-dashboard.git
+  make
+  docker run -it -p 5006:5006 -p 8000:8000 lsstsqre/squash
+```
+Then access the application at http://localhost:8000 
+
+## Using virtualenv
+
 1. Clone the project, create a virtualenv and install dependencies
 ```
   git clone  https://github.com/lsst-sqre/qa-dashboard.git

--- a/squash/supervisord.conf
+++ b/squash/supervisord.conf
@@ -1,0 +1,26 @@
+[supervisord]
+nodaemon=true                                 ; run supervisor in foreground otherwise docker run exits
+
+[program:mysql]
+user=root
+command=/usr/bin/mysqld_safe
+stdout_logfile=/var/log/supervisor/mysql.log
+redirect_stderr=true                          ; Save stderr in the same log
+autostart=true
+
+[program:django]
+user=root
+; by default django listens to the "image localhost", since we are forwarding port 8000 to
+; the "external host" we have to make it listen to all interfaces
+; --noreload is needed to pass the control to supervisor
+command=/usr/local/bin/python /usr/src/app/squash/manage.py runserver 0.0.0.0:8000 --noreload
+stdout_logfile=/var/log/supervisor/django.log
+redirect_stderr=true
+autostart=true
+
+[program:bokeh]
+user=root
+command=/usr/local/bin/bokeh serve --allow-websocket-origin=localhost:8000 dashboard/viz/AMx dashboard/viz/PAx dashboard/viz/monitor
+stdout_logfile=/var/log/supervisor/bokeh.log
+redirect_stderr=true
+autostart=true


### PR DESCRIPTION
Created a Dockerfile for squash development, it uses supervisord to manage mariadb (mysql), django and bokeh processes. It is a monolithic docker image more for practicing docker commands than anything else, but still useful. The Makefile has the docker command to build the image, and you should be able to run it with:

docker run -it -p 5006:5006 -p 8000:8000 lsstsqre/squash

then access squash at http://localhost:8000

More info at https://jira.lsstcorp.org/browse/DM-11042